### PR TITLE
Add ability to verify CMS signing time against current time and threshold.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# a Python library for decrypting Apple Pay payment tokens.
+# A Python library for decrypting Apple Pay payment tokens.
 
 ApplePay reference https://developer.apple.com/library/ios/documentation/PassKit/Reference/PaymentTokenJSON/PaymentTokenJSON.html
 
@@ -61,9 +61,7 @@ decrypted_json = payment.decrypt(payment_json['header']['ephemeralPublicKey'], p
 ## Testing
 
 ```sh
-
-#FIXME
-
+$ python setup.py test
 ```
 
 ## Contributors

--- a/applepay/payment.py
+++ b/applepay/payment.py
@@ -80,6 +80,9 @@ class Payment(object):
         :type: timedelta
         :return: False if the signing time exceeds the threshold, otherwise True
         :rtype: bool
+        :raises: AttributeError if no 'signingTime' attribute can be found,
+        indicating an invalid token. May also raise if signature data is in an
+        unexpected format, inconsistent with the CMS 'ContentInfo' object.
         """
         signing_time = payment_utils.retrieve_signature_signing_time(signature)
         return timedelta(0) <= (current_time - signing_time) <= threshold

--- a/applepay/payment.py
+++ b/applepay/payment.py
@@ -1,6 +1,5 @@
 from base64 import b64decode
 from binascii import unhexlify
-from datetime import timedelta
 from hashlib import sha256
 
 from cryptography.hazmat.backends import default_backend
@@ -9,8 +8,6 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from cryptography.hazmat.primitives.serialization import load_der_public_key
 from cryptography.x509 import load_pem_x509_certificate, load_der_x509_certificate
-
-import utils as payment_utils
 
 
 OID_MERCHANT_ID = "1.2.840.113635.100.6.32"
@@ -63,29 +60,6 @@ class Payment(object):
         sha.update(b'\x0did-aes256-GCM' + b'Apple' + self._merc_id)
 
         return sha.digest()
-
-    @staticmethod
-    def signing_time_is_valid(signature, current_time, threshold):
-        """ Given a detached top-level CMS signature, validate the 'signingTime'
-        attribute against the current time and a time-delta threshold.
-
-        If the difference between the current time and the 'signingTime' exceeds
-        the threshold, the token should be considered invalid.
-
-        :param signature: Base64 encoded detached CMS signature data.
-        :type: str
-        :param current_time: Current system time to compare the token against.
-        :type: offset-aware datetime
-        :param threshold: Amount of time to consider the token valid.
-        :type: timedelta
-        :return: False if the signing time exceeds the threshold, otherwise True
-        :rtype: bool
-        :raises: AttributeError if no 'signingTime' attribute can be found,
-        indicating an invalid token. May also raise if signature data is in an
-        unexpected format, inconsistent with the CMS 'ContentInfo' object.
-        """
-        signing_time = payment_utils.retrieve_signature_signing_time(signature)
-        return timedelta(0) <= (current_time - signing_time) <= threshold
 
     def decrypt(self, ephemeral_public_key, cipher_data, transaction_id=None, application_data=''):
 

--- a/applepay/payment.py
+++ b/applepay/payment.py
@@ -1,15 +1,17 @@
+from base64 import b64decode
+from binascii import unhexlify
+from datetime import timedelta
+from hashlib import sha256
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import ciphers, hashes
+from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from cryptography.hazmat.primitives.serialization import load_der_public_key
-from cryptography.hazmat.primitives.asymmetric import ec
-
 from cryptography.x509 import load_pem_x509_certificate, load_der_x509_certificate
-from cryptography.hazmat.primitives import ciphers, hashes
-from cryptography.hazmat.backends import default_backend
 
+import utils as payment_utils
 
-from binascii import unhexlify
-from base64 import b64decode
-from hashlib import sha256
 
 OID_MERCHANT_ID = "1.2.840.113635.100.6.32"
 OID_LEAF_CERTIFICATE = "1.2.840.113635.100.6.29"
@@ -61,6 +63,26 @@ class Payment(object):
         sha.update(b'\x0did-aes256-GCM' + b'Apple' + self._merc_id)
 
         return sha.digest()
+
+    @staticmethod
+    def signing_time_is_valid(signature, current_time, threshold):
+        """ Given a detached top-level CMS signature, validate the 'signingTime'
+        attribute against the current time and a time-delta threshold.
+
+        If the difference between the current time and the 'signingTime' exceeds
+        the threshold, the token should be considered invalid.
+
+        :param signature: Base64 encoded detached CMS signature data.
+        :type: str
+        :param current_time: Current system time to compare the token against.
+        :type: offset-aware datetime
+        :param threshold: Amount of time to consider the token valid.
+        :type: timedelta
+        :return: False if the signing time exceeds the threshold, otherwise True
+        :rtype: bool
+        """
+        signing_time = payment_utils.retrieve_signature_signing_time(signature)
+        return timedelta(0) <= (current_time - signing_time) <= threshold
 
     def decrypt(self, ephemeral_public_key, cipher_data, transaction_id=None, application_data=''):
 

--- a/applepay/utils.py
+++ b/applepay/utils.py
@@ -1,0 +1,29 @@
+import base64
+
+from asn1crypto import cms
+
+
+def retrieve_signature_signing_time(signature):
+    """ Return the 'signingTime' CMS attribute from the detached PKCS signature.
+
+    This parsing depends on the structure of 'ContentInfo' objects defined in
+    RFC-5652 (specifically the inner OID 1.2.840.113549.1.9.5):
+      https://tools.ietf.org/html/rfc5652#section-11.3
+
+    :param signature: Base64 encoded signature data (of a 'ContentInfo' object).
+    :type: str
+    :return: A datetime object representing the inner 'signingTime' object.
+    :rtype: datetime
+    :raises: AttributeError if no 'signing_time' object can be found.
+    """
+    data = base64.b64decode(signature)
+    content_info = cms.ContentInfo.load(data)
+    signer_data = content_info['content']
+    signer_infos = signer_data['signer_infos']
+    signer_info = signer_infos[0]  # We expect only one item in the list.
+    signed_attrs = signer_info['signed_attrs']
+    for signed_attr in signed_attrs:
+        if 'signing_time' == signed_attr['type'].native:
+            value = signed_attr['values']
+            return value.native[0]  # datetime object, only item in the list.
+    raise AttributeError('No signing_time attribute found in signature.')

--- a/applepay/utils.py
+++ b/applepay/utils.py
@@ -1,4 +1,5 @@
 import base64
+from datetime import timedelta
 
 from asn1crypto import cms
 
@@ -27,3 +28,26 @@ def retrieve_signature_signing_time(signature):
             value = signed_attr['values']
             return value.native[0]  # datetime object, only item in the list.
     raise AttributeError('No signing_time attribute found in signature.')
+
+
+def signing_time_is_valid(signature, current_time, threshold):
+    """ Given a detached top-level CMS signature, validate the 'signingTime'
+    attribute against the current time and a time-delta threshold.
+
+    If the difference between the current time and the 'signingTime' exceeds
+    the threshold, the token should be considered invalid.
+
+    :param signature: Base64 encoded detached CMS signature data.
+    :type: str
+    :param current_time: Current system time to compare the token against.
+    :type: offset-aware datetime
+    :param threshold: Amount of time to consider the token valid.
+    :type: timedelta
+    :return: False if the signing time exceeds the threshold, otherwise True
+    :rtype: bool
+    :raises: AttributeError if no 'signingTime' attribute can be found,
+    indicating an invalid token. May also raise if signature data is in an
+    unexpected format, inconsistent with the CMS 'ContentInfo' object.
+    """
+    signing_time = retrieve_signature_signing_time(signature)
+    return timedelta(0) <= (current_time - signing_time) <= threshold

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[aliases]
+test = pytest
+
+[tool:pytest]
+addopts = --verbose
+python_files = tests/*.py

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,18 @@
-import os
 from setuptools import setup
 
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
-
 setup(
-    name = "applepay",
-    version = "0.3.1",
-    author = "Taras Halturin",
-    author_email = "halturin@gmail.com",
-    description = ("a Python library for decrypting Apple Pay payment tokens."),
-    license = "BSD",
-    keywords = "applepay payment tokens",
-    url = "https://github.com/halturin/applepay",
+    name="applepay",
+    version="0.3.1",
+    author="Taras Halturin",
+    author_email="halturin@gmail.com",
+    description=("A Python library for decrypting Apple Pay payment tokens."),
+    license="BSD",
+    keywords="applepay payment tokens",
+    url="https://github.com/halturin/applepay",
     packages=['applepay', 'tests'],
-    install_requires=[
-        'cryptography',
-    ],
+    install_requires=['asn1crypto>=0.21.0', 'cryptography>=1.7.2'],
+    setup_requires=['pytest-runner>=2.0,<3dev'],
+    tests_require=['pytest>=3.0.6'],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Topic :: Utilities",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     packages=['applepay', 'tests'],
     install_requires=['asn1crypto>=0.21.0', 'cryptography>=1.7.2'],
     setup_requires=['pytest-runner>=2.0,<3dev'],
-    tests_require=['pytest>=3.0.6'],
+    tests_require=['pytest>=3.0.6', 'pytz==2016.10'],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Topic :: Utilities",

--- a/tests/applepay_test.py
+++ b/tests/applepay_test.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 
 from pytz import utc
 
-from applepay import payment
 from applepay import utils as applepay_utils
 
 import utils as test_utils
@@ -33,7 +32,7 @@ def test_valid_signing_time():
     threshold = timedelta(hours=1)
 
     # when we attempt to validate the signing time against the threshold,
-    valid = payment.Payment.signing_time_is_valid(signature, current_time, threshold)
+    valid = applepay_utils.signing_time_is_valid(signature, current_time, threshold)
 
     # then the token should be considered valid.
     assert valid is True
@@ -51,7 +50,7 @@ def test_expired_signing_time():
     threshold = timedelta(days=1)
 
     # when we attempt to validate the signing time against the threshold,
-    valid = payment.Payment.signing_time_is_valid(signature, current_time, threshold)
+    valid = applepay_utils.signing_time_is_valid(signature, current_time, threshold)
 
     # then the token should be considered invalid.
     assert valid is False
@@ -69,7 +68,7 @@ def test_future_signing_time():
     threshold = timedelta(weeks=5)
 
     # when we attempt to validate the signing time against the threshold,
-    valid = payment.Payment.signing_time_is_valid(signature, current_time, threshold)
+    valid = applepay_utils.signing_time_is_valid(signature, current_time, threshold)
 
     # then the token should be considered invalid.
     assert valid is False
@@ -87,7 +86,7 @@ def test_signing_time_equals_current_time():
     threshold = timedelta(0)
 
     # when we attempt to validate the signing time against the threshold,
-    valid = payment.Payment.signing_time_is_valid(signature, current_time, threshold)
+    valid = applepay_utils.signing_time_is_valid(signature, current_time, threshold)
 
     # then the token should be considered valid.
     assert valid is True

--- a/tests/applepay_test.py
+++ b/tests/applepay_test.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+from pytz import utc
+
+from applepay import utils as applepay_utils
+
+import utils as test_utils
+
+
+def test_retrieve_signature_signing_time():
+    # Given a detached CMS signature in the token,
+    token = test_utils.load_json_fixture('tests/fixtures/token.json')
+    signature = token['signature']
+
+    # when we attempt to retrieve the signing time from the signature,
+    signing_time = applepay_utils.retrieve_signature_signing_time(signature)
+
+    # then the signing time matches the datetime we expect.
+    expected_time = datetime(2014, 10, 27, 19, 51, 43, tzinfo=utc)
+    assert signing_time == expected_time

--- a/tests/applepay_test.py
+++ b/tests/applepay_test.py
@@ -1,6 +1,8 @@
-from datetime import datetime
+from datetime import datetime, timedelta
+
 from pytz import utc
 
+from applepay import payment
 from applepay import utils as applepay_utils
 
 import utils as test_utils
@@ -17,3 +19,75 @@ def test_retrieve_signature_signing_time():
     # then the signing time matches the datetime we expect.
     expected_time = datetime(2014, 10, 27, 19, 51, 43, tzinfo=utc)
     assert signing_time == expected_time
+
+
+def test_valid_signing_time():
+    # Given a detached CMS signature in the token,
+    token = test_utils.load_json_fixture('tests/fixtures/token.json')
+    signature = token['signature']
+
+    # and a current time exactly one hour past the signing time,
+    current_time = datetime(2014, 10, 27, 20, 51, 43, tzinfo=utc)
+
+    # and a time-delta threshold of one hour,
+    threshold = timedelta(hours=1)
+
+    # when we attempt to validate the signing time against the threshold,
+    valid = payment.Payment.signing_time_is_valid(signature, current_time, threshold)
+
+    # then the token should be considered valid.
+    assert valid is True
+
+
+def test_expired_signing_time():
+    # Given a detached CMS signature in the token,
+    token = test_utils.load_json_fixture('tests/fixtures/token.json')
+    signature = token['signature']
+
+    # and a current time well past the signing time,
+    current_time = datetime(2017, 2, 16, 17, 9, 55, tzinfo=utc)
+
+    # and a time-delta threshold of only one day,
+    threshold = timedelta(days=1)
+
+    # when we attempt to validate the signing time against the threshold,
+    valid = payment.Payment.signing_time_is_valid(signature, current_time, threshold)
+
+    # then the token should be considered invalid.
+    assert valid is False
+
+
+def test_future_signing_time():
+    # Given a detached CMS signature in the token,
+    token = test_utils.load_json_fixture('tests/fixtures/token.json')
+    signature = token['signature']
+
+    # and a current time which is well before the signing time,
+    current_time = datetime(2010, 1, 2, 5, 22, 13, tzinfo=utc)
+
+    # and a time-delta threshold of five weeks,
+    threshold = timedelta(weeks=5)
+
+    # when we attempt to validate the signing time against the threshold,
+    valid = payment.Payment.signing_time_is_valid(signature, current_time, threshold)
+
+    # then the token should be considered invalid.
+    assert valid is False
+
+
+def test_signing_time_equals_current_time():
+    # Given a detached CMS signature in the token,
+    token = test_utils.load_json_fixture('tests/fixtures/token.json')
+    signature = token['signature']
+
+    # and a current time that exactly matches the signing time,
+    current_time = datetime(2014, 10, 27, 19, 51, 43, tzinfo=utc)
+
+    # and a time-delta of zero,
+    threshold = timedelta(0)
+
+    # when we attempt to validate the signing time against the threshold,
+    valid = payment.Payment.signing_time_is_valid(signature, current_time, threshold)
+
+    # then the token should be considered valid.
+    assert valid is True

--- a/tests/applepay_test.py
+++ b/tests/applepay_test.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 
+import pytest
 from pytz import utc
 
 from applepay import utils as applepay_utils
@@ -7,10 +8,14 @@ from applepay import utils as applepay_utils
 import utils as test_utils
 
 
-def test_retrieve_signature_signing_time():
+@pytest.fixture(scope='session')
+def token_fixture():
+    return test_utils.load_json_fixture('tests/fixtures/token.json')
+
+
+def test_retrieve_signature_signing_time(token_fixture):
     # Given a detached CMS signature in the token,
-    token = test_utils.load_json_fixture('tests/fixtures/token.json')
-    signature = token['signature']
+    signature = token_fixture['signature']
 
     # when we attempt to retrieve the signing time from the signature,
     signing_time = applepay_utils.retrieve_signature_signing_time(signature)
@@ -20,10 +25,9 @@ def test_retrieve_signature_signing_time():
     assert signing_time == expected_time
 
 
-def test_valid_signing_time():
+def test_valid_signing_time(token_fixture):
     # Given a detached CMS signature in the token,
-    token = test_utils.load_json_fixture('tests/fixtures/token.json')
-    signature = token['signature']
+    signature = token_fixture['signature']
 
     # and a current time exactly one hour past the signing time,
     current_time = datetime(2014, 10, 27, 20, 51, 43, tzinfo=utc)
@@ -38,10 +42,9 @@ def test_valid_signing_time():
     assert valid is True
 
 
-def test_expired_signing_time():
+def test_expired_signing_time(token_fixture):
     # Given a detached CMS signature in the token,
-    token = test_utils.load_json_fixture('tests/fixtures/token.json')
-    signature = token['signature']
+    signature = token_fixture['signature']
 
     # and a current time well past the signing time,
     current_time = datetime(2017, 2, 16, 17, 9, 55, tzinfo=utc)
@@ -56,10 +59,9 @@ def test_expired_signing_time():
     assert valid is False
 
 
-def test_future_signing_time():
+def test_future_signing_time(token_fixture):
     # Given a detached CMS signature in the token,
-    token = test_utils.load_json_fixture('tests/fixtures/token.json')
-    signature = token['signature']
+    signature = token_fixture['signature']
 
     # and a current time which is well before the signing time,
     current_time = datetime(2010, 1, 2, 5, 22, 13, tzinfo=utc)
@@ -74,10 +76,9 @@ def test_future_signing_time():
     assert valid is False
 
 
-def test_signing_time_equals_current_time():
+def test_signing_time_equals_current_time(token_fixture):
     # Given a detached CMS signature in the token,
-    token = test_utils.load_json_fixture('tests/fixtures/token.json')
-    signature = token['signature']
+    signature = token_fixture['signature']
 
     # and a current time that exactly matches the signing time,
     current_time = datetime(2014, 10, 27, 19, 51, 43, tzinfo=utc)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,12 @@
+import json
+
+
+def load_json_fixture(path):
+    """ Return the Python representation of the JSON fixture stored in path.
+    :param path: Local path to JSON fixture file.
+    :type: str
+    :return: Python representation of JSON content.
+    :rtype: object
+    """
+    with open(path, 'r') as f:
+        return json.load(f)


### PR DESCRIPTION
These additions enable the detached CMS signature data in the top-level structure of the token to be validated against the current system time and a threshold. This helps ensure the validity of the request token against replay attacks. Please see item '1.e' in the Apple Pay payment token format [documentation](https://developer.apple.com/library/content/documentation/PassKit/Reference/PaymentTokenJSON/PaymentTokenJSON.html):

> Inspect the CMS signing time of the signature, as defined by section 11.3 of RFC 5652. If the time signature and the transaction time differ by more than a few minutes, it's possible that the token is a replay attack.

I have done some minor cleanup and added the py.test runner to the project. Please also find unit tests covering the new functionality. These changes introduce a new dependency on asn1crypto, however, this library is slated to be used by the cryptography library in their next release.

Items to consider:
- Is raising an `AttributeError` from the utility method a viable approach if the signing time attribute is not found? Would relegating this responsibility to the caller be better?
- I was unable to discover the proper method in as1crypto for accessing the signing time attribute from the ContentInfo object using the OID. Does this matter?