### PR TITLE
Add debug logging to `signing_time_is_valid`

### DIFF
--- a/applepay/utils.py
+++ b/applepay/utils.py
@@ -1,7 +1,11 @@
 import base64
 from datetime import timedelta
+import logging
 
 from asn1crypto import cms
+
+
+logger = logging.getLogger('applepay.utils')
 
 
 def retrieve_signature_signing_time(signature):
@@ -50,4 +54,15 @@ def signing_time_is_valid(signature, current_time, threshold):
     unexpected format, inconsistent with the CMS 'ContentInfo' object.
     """
     signing_time = retrieve_signature_signing_time(signature)
-    return timedelta(0) <= (current_time - signing_time) <= threshold
+    is_valid = timedelta(0) <= (current_time - signing_time) <= threshold
+    logger.debug((
+        "Signing time is {is_valid}. "
+        "Signing time: {signing_time:%Y-%m-%d %H:%M:%S %Z}, "
+        "Current time: {current_time:%Y-%m-%d %H:%M:%S %Z}, "
+        "Threshold: {threshold}.").format(
+        is_valid='valid' if is_valid else 'invalid',
+        signing_time=signing_time,
+        threshold=threshold,
+        current_time=current_time)
+    )
+    return is_valid

--- a/applepay/utils.py
+++ b/applepay/utils.py
@@ -5,7 +5,7 @@ import logging
 from asn1crypto import cms
 
 
-logger = logging.getLogger('applepay.utils')
+logger = logging.getLogger(__name__)
 
 
 def retrieve_signature_signing_time(signature):

--- a/applepay/utils.py
+++ b/applepay/utils.py
@@ -62,7 +62,7 @@ def signing_time_is_valid(signature, current_time, threshold):
         "Threshold: {threshold}.").format(
         is_valid='valid' if is_valid else 'invalid',
         signing_time=signing_time,
-        threshold=threshold,
-        current_time=current_time)
+        current_time=current_time,
+        threshold=threshold)
     )
     return is_valid

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     packages=['applepay', 'tests'],
     install_requires=['asn1crypto>=0.21.0', 'cryptography>=1.7.2'],
     setup_requires=['pytest-runner>=2.0,<3dev'],
-    tests_require=['pytest>=3.0.6', 'pytz==2016.10'],
+    tests_require=['pytest>=3.0.6', 'pytz==2016.10', 'pytest-capturelog>=0.7'],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Topic :: Utilities",


### PR DESCRIPTION
This updates `signing_time_is_valid` to log.debug potentially useful information about the signing time of the signature and the check against "now".

This PR introduces a new test requirement, [pytest-capturelog](https://pypi.python.org/pypi/pytest-capturelog), which allows for easy capturing of logging.
